### PR TITLE
Fiew updates: begin() method and SkipROM support

### DIFF
--- a/DS2431.cpp
+++ b/DS2431.cpp
@@ -24,23 +24,31 @@ SOFTWARE.
 
 #include "DS2431.h"
 
-DS2431::DS2431(OneWire &ow, uint8_t serialNumber[8])
+DS2431::DS2431(OneWire &ow)
 : _ow(ow)
-{
-  memcpy(_serialNumber, serialNumber, 8);
+{  
 }
 
-uint8_t DS2431::read(uint16_t address)
+void DS2431::begin(uint8_t serialNumber[8])
+{
+  memcpy(_serialNumber, serialNumber, 8);
+  _init = true;
+}
+
+int DS2431::read(uint16_t address)
 {
   uint8_t res = 0xFF;
 
-  read(address, &res, 1);
-
+  if(!read(address, &res, 1))
+	  return -1;
+  
   return res;
 }
 
-void DS2431::read(uint16_t address, uint8_t *buf, uint16_t len)
+bool DS2431::read(uint16_t address, uint8_t *buf, uint16_t len)
 {
+	if (!_init)
+		return false;
   _ow.reset();
   _ow.select(_serialNumber);
   _ow.write(READ_MEMORY, 1);
@@ -51,6 +59,8 @@ void DS2431::read(uint16_t address, uint8_t *buf, uint16_t len)
     buf[i] = _ow.read();
 
   _ow.depower();
+  
+  return true;
 }
 
 bool DS2431::write(uint16_t address, uint8_t buf[8])

--- a/DS2431.cpp
+++ b/DS2431.cpp
@@ -2,6 +2,7 @@
 MIT License
 
 Copyright (c) 2017 Tom Magnier
+Modified 2018 by Nicolò Veronese
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -26,92 +27,121 @@ SOFTWARE.
 
 DS2431::DS2431(OneWire &ow)
 : _ow(ow)
-{  
-}
-
-void DS2431::begin(uint8_t serialNumber[8])
 {
-  memcpy(_serialNumber, serialNumber, 8);
-  _init = true;
+  _skiprom = true;
 }
 
-int DS2431::read(uint16_t address)
+void DS2431::begin(uint8_t serialNumber[ONE_WIRE_MAC_SIZE])
+{
+  memcpy(_serialNumber, serialNumber, ONE_WIRE_MAC_SIZE);
+  _skiprom = false;
+}
+
+uint8_t DS2431::read(uint16_t address)
 {
   uint8_t res = 0xFF;
+  read(address, &res, 1);
 
-  if(!read(address, &res, 1))
-	  return -1;
-  
   return res;
 }
 
-bool DS2431::read(uint16_t address, uint8_t *buf, uint16_t len)
+void DS2431::read(uint16_t address, uint8_t *buf, uint16_t len)
 {
-	if (!_init)
-		return false;
-  _ow.reset();
-  _ow.select(_serialNumber);
+  _startTransmission();
+
   _ow.write(READ_MEMORY, 1);
   _ow.write(lowByte(address), 1);
   _ow.write(highByte(address), 1);
 
   for (int i = 0; i < len; i++)
-    buf[i] = _ow.read();
+  buf[i] = _ow.read();
 
   _ow.depower();
-  
-  return true;
 }
 
-bool DS2431::write(uint16_t address, uint8_t buf[8])
+bool DS2431::write(uint16_t address, const uint8_t *buf, uint16_t count, bool verify /* = 0 */)
 {
-  if (address >= EEPROM_SIZE || address % 8 != 0) //Address has to be aligned on an 8-byte boundary
+  bool ret = _write(address, buf, count, verify);
+  _ow.depower();
+  return ret;
+}
+
+bool DS2431::_write(uint16_t address, const uint8_t *buf, uint16_t count, bool verify)
+{
+  uint8_t error_count = 0;
+  uint8_t buffer[DS2431_BUFFER_SIZE];
+  uint8_t crc16[DS2431_CRC_SIZE];
+
+  //Address has to be aligned on an 8-byte boundary
+  if (address >= DS2431_EEPROM_SIZE || address % 8 != 0)
     return false;
 
-  //Write scratchpad with CRC check
-  uint8_t buffer[13];
+  // Prepare buffer data
   buffer[0] = WRITE_SCRATCHPAD;
   buffer[1] = lowByte(address);
   buffer[2] = highByte(address);
-  memcpy(&buffer[3], buf, 8);
+  memcpy(&buffer[DS2431_CMD_SIZE], buf, count);
 
-  _ow.reset();
-  _ow.select(_serialNumber);
-  _ow.write_bytes(buffer, 11, 1);
-  _ow.read_bytes(&buffer[11], 2); //Read CRC-16
+  //Write scratchpad with CRC check
+  _startTransmission();
+  _ow.write_bytes(buffer, DS2431_CMD_SIZE + count, 1); // Write CMD + LSB Adr + MSB Adr
+  _ow.read_bytes(crc16, DS2431_CRC_SIZE); //Read CRC-16
 
-  if (!_ow.check_crc16(buffer, 11, &buffer[11]))
-    return false; //CRC not matching
+  if (!_ow.check_crc16(buffer, DS2431_CMD_SIZE + count, crc16)){
+    verify = true; //CRC not matching, try to read again
+  }
 
-  //Read scratchpad
+  // Read verification
+  // Prepare buffer data
   buffer[0] = READ_SCRATCHPAD;
+  do {
+    //Read scratchpad to compare with the data sent
+    _startTransmission();
+    _ow.write(buffer[0], 1); // Write CMD
+    _ow.read_bytes(&buffer[1], DS2431_CMD_SIZE); //Read TA1, TA2, E/S, scratchpad
 
-  _ow.reset();
-  _ow.select(_serialNumber);
-  _ow.write(buffer[0], 1);
-  _ow.read_bytes(&buffer[1], 13); //Read TA1, TA2, E/S, scratchpad and CRC
+    if (buffer[3] != DS2431_PF_MASK) {
+      verify = true;
+    }
 
-  if (!_ow.check_crc16(buffer, 12, &buffer[12]))
-    return false; //CRC not matching. TODO this does not indicate that scratchpad data is invalid, retry read instead ?
+    if(verify) {
+      _ow.read_bytes(&buffer[4], count); //Read scratchpad
+      _ow.read_bytes(crc16, DS2431_CRC_SIZE); //Read CRC-16
 
-  if (address != ((buffer[2] << 8) + buffer[1]))
-    return false; //Address not matching
+      if (!_ow.check_crc16(buffer, 12, crc16)) {
+        error_count++; //CRC not matching.
+        continue;
+      }
 
-  if (buffer[3] != 0x07)
-    return false; //Invalid transfer or data already copied (wrong value for E/S).
+      if (address != ((buffer[2] << 8) + buffer[1])) {
+        return false; //Address not matching
+      }
 
-  if (memcmp(&buffer[4], buf, 8) != 0)
-    return false; //Data in the scratchpad is invalid.
+      if (buffer[3] != DS2431_PF_MASK) {
+        return false; //Invalid transfer or data already copied (wrong value for E/S).
+      }
+
+      if (memcmp(&buffer[4], buf, 8) != 0) {
+        return false; //Data in the scratchpad is invalid.
+      }
+    }
+
+    break;
+  } while(error_count < DS2431_READ_RETRY);
+
+  // Prepare buffer data
+  buffer[0] = COPY_SCRATCHPAD;
 
   //Copy scratchpad
-  _ow.reset();
-  _ow.select(_serialNumber);
-  _ow.write(COPY_SCRATCHPAD, 1);
-  _ow.write_bytes(&buffer[1], 3, 1); //Send authorization code (TA1, TA2, E/S)
+  _startTransmission();
+  _ow.write_bytes(buffer, DS2431_CMD_SIZE + 1, 1); //Send authorization code (TA1, TA2, E/S)
   delay(15); // t_PROG = 12.5ms worst case.
 
-  if (_ow.read() != 0xAA)
+  uint8_t res = _ow.read();
+
+  if (res != DS2431_WRITE_MASK) {
     return false;
+  }
 
   return true;
 }

--- a/DS2431.h
+++ b/DS2431.h
@@ -2,6 +2,7 @@
 MIT License
 
 Copyright (c) 2017 Tom Magnier
+Modified 2018 by Nicolò Veronese
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -29,32 +30,46 @@ SOFTWARE.
 
 class DS2431 {
 public:
+  const static uint8_t ONE_WIRE_MAC_SIZE = 8;
+
   const static uint8_t ONE_WIRE_FAMILY_CODE = 0x2D;
 
+  const static uint8_t DS2431_EEPROM_SIZE = 128;
+  const static uint8_t DS2431_ROW_SIZE = 8;
+
   DS2431(OneWire &ow); // OneWire class
-	
-  void begin(uint8_t serialNumber[8]); // family code, 48bit serial number and CRC as returned by OneWire search function
+
+  void begin(uint8_t serialNumber[ONE_WIRE_MAC_SIZE]); // family code, 48bit serial number and CRC as returned by OneWire search function
 
   /* Single byte read
   */
-  int read(uint16_t address);
+  uint8_t read(uint16_t address);
 
   /* Multiple byte read.
   */
-  bool read(uint16_t address, uint8_t *buf, uint16_t len);
+  void read(uint16_t address, uint8_t *buf, uint16_t len);
 
-  /* Full row (8 byte) write. Please note : address must be a multiple of 8.
-  Return true if operation was successful.
-  The OneWire bus should be de-powered after calling this function.
+  /* Multiple byte write.
+    Please note : address must be a multiple of 8. Write up to 8 bytes
+    Return true if operation was successful.
+    The OneWire bus should be de-powered after calling this function.
   */
-  bool write(uint16_t address, uint8_t buf[8]);
+  bool write(uint16_t address, const uint8_t *buf, uint16_t count, bool verify = false);
 
 private:
-  OneWire &_ow;
-  uint8_t _serialNumber[8];
-  bool _init;
+  const static uint8_t DS2431_PF_MASK = 0x07;
+  const static uint8_t DS2431_WRITE_MASK = 0xAA;
 
-  const static uint16_t EEPROM_SIZE = 128;
+  const static uint8_t DS2431_CMD_SIZE = 3;
+  const static uint8_t DS2431_CRC_SIZE = 2;
+
+  const static uint8_t DS2431_READ_RETRY = 2;
+
+  const static uint16_t DS2431_BUFFER_SIZE = DS2431_ROW_SIZE + DS2431_CMD_SIZE + DS2431_CRC_SIZE;
+
+  OneWire &_ow;
+  uint8_t _serialNumber[ONE_WIRE_MAC_SIZE];
+  bool _skiprom;
 
   enum Commands {
     WRITE_SCRATCHPAD = 0x0F,
@@ -62,6 +77,17 @@ private:
     COPY_SCRATCHPAD = 0x55,
     READ_MEMORY = 0xF0
   };
+
+  bool _write(uint16_t address, const uint8_t *buf, uint16_t count, bool verify);
+
+  inline void _startTransmission()
+  {
+    _ow.reset();
+    if (_skiprom)
+    _ow.skip();
+    else
+    _ow.select(_serialNumber);
+  }
 };
 
 #endif // _DS2431_H

--- a/DS2431.h
+++ b/DS2431.h
@@ -31,16 +31,17 @@ class DS2431 {
 public:
   const static uint8_t ONE_WIRE_FAMILY_CODE = 0x2D;
 
-  DS2431(OneWire &ow, // OneWire class
-    uint8_t serialNumber[8]); // family code, 48bit serial number and CRC as returned by OneWire search function
+  DS2431(OneWire &ow); // OneWire class
+	
+  void begin(uint8_t serialNumber[8]); // family code, 48bit serial number and CRC as returned by OneWire search function
 
   /* Single byte read
   */
-  uint8_t read(uint16_t address);
+  int read(uint16_t address);
 
   /* Multiple byte read.
   */
-  void read(uint16_t address, uint8_t *buf, uint16_t len);
+  bool read(uint16_t address, uint8_t *buf, uint16_t len);
 
   /* Full row (8 byte) write. Please note : address must be a multiple of 8.
   Return true if operation was successful.
@@ -51,6 +52,7 @@ public:
 private:
   OneWire &_ow;
   uint8_t _serialNumber[8];
+  bool _init;
 
   const static uint16_t EEPROM_SIZE = 128;
 

--- a/examples/DS2431_ReadWrite/DS2431_ReadWrite.ino
+++ b/examples/DS2431_ReadWrite/DS2431_ReadWrite.ino
@@ -32,6 +32,7 @@ SOFTWARE.
 const int ONE_WIRE_PIN = 9; // One Wire pin, change according to your needs. A 4.7k pull up resistor is needed.
 
 OneWire oneWire(ONE_WIRE_PIN);
+DS2431 eeprom(oneWire);
 
 void setup()
 {
@@ -59,7 +60,7 @@ void setup()
   Serial.println("");
 
   // Initialize DS2431 object
-  DS2431 eeprom(oneWire, serialNb);
+  eeprom.begin(serialNb);
 
   // Read all memory content
   byte data[128];

--- a/examples/DS2431_ReadWrite/DS2431_ReadWrite.ino
+++ b/examples/DS2431_ReadWrite/DS2431_ReadWrite.ino
@@ -73,7 +73,7 @@ void setup()
   // Write a 8-byte row
   byte newData[] = {1,2,3,4,5,6,7,8};
   word address = 0;
-  if (eeprom.write(address, newData))
+  if (eeprom.write(address, newData, sizeof(newData)))
   {
     Serial.print("Successfully wrote new data @ address ");
     Serial.println(address);
@@ -83,7 +83,6 @@ void setup()
     Serial.print("Failed to write data @ address ");
     Serial.println(address);
   }
-  oneWire.depower(); // Call this after writing to avoid leaving the bus powered.
   Serial.println("");
 
   // Read again memory content

--- a/examples/DS2431_ReadWriteSkip/DS2431_ReadWriteSkip.ino
+++ b/examples/DS2431_ReadWriteSkip/DS2431_ReadWriteSkip.ino
@@ -1,0 +1,110 @@
+/*
+
+DS2431 example that dumps the whole memory and prints it to Serial.
+Then a write operation is done and the memory is read again.
+
+MIT License
+
+Copyright (c) 2018 Nicolò Veronese
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#include <DS2431.h>
+#include <OneWire.h>
+
+const int ONE_WIRE_PIN = 9; // One Wire pin, change according to your needs. A 4.7k pull up resistor is needed.
+
+OneWire oneWire(ONE_WIRE_PIN);
+DS2431 eeprom(oneWire);
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial); // wait for Serial to come up on USB boards
+  
+  if(!oneWire.reset())
+  {
+    Serial.println("No DS2431 found on the 1-Wire bus.");
+    return;
+  }
+
+  // Read all memory content
+  byte data[128];
+  eeprom.read(0, data, sizeof(data));
+
+  Serial.println("Memory contents : ");
+  printLargeBuffer(data, sizeof(data));
+  Serial.println("");
+
+  // Write a 8-byte row
+  byte newData[] = {1,2,3,4,5,6,7,8};
+  word address = 0;
+  if (eeprom.write(address, newData, sizeof(newData)))
+  {
+    Serial.print("Successfully wrote new data @ address ");
+    Serial.println(address);
+  }
+  else
+  {
+    Serial.print("Failed to write data @ address ");
+    Serial.println(address);
+  }
+  Serial.println("");
+
+  // Read again memory content
+  eeprom.read(0, data, sizeof(data));
+
+  Serial.println("Memory contents : ");
+  printLargeBuffer(data, sizeof(data));
+  Serial.println("");
+
+  // Read single byte
+  Serial.print("Data @ address ");
+  Serial.print(address);
+  Serial.print(" : ");
+  Serial.println(eeprom.read(address));
+}
+
+void loop()
+{
+  // Nothing to do
+}
+
+void printBuffer(const uint8_t *buf, uint8_t len)
+{
+  for (int i = 0; i < len-1; i++)
+  {
+    Serial.print(buf[i], HEX);
+    Serial.print(",");
+  }
+  Serial.println(buf[len-1], HEX);
+}
+
+void printLargeBuffer(const uint8_t *buf, uint16_t len)
+{
+  uint8_t bytesPerLine = 8;
+
+  for (int i = 0; i < len / bytesPerLine; i++)
+  {
+    Serial.print(i * bytesPerLine);
+    Serial.print("\t\t:");
+    printBuffer(buf + i * bytesPerLine, bytesPerLine);
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DS2431
-version=1.0
+version=1.1
 author=Tom Magnier
 maintainer=Tom Magnier<tom@tmagnier.fr>
 sentence=Arduino library for Maxim DS2431 1-Wire EEPROM


### PR DESCRIPTION
Added:

- begin() method

- SkipROM support

Modified:

- Write now need the array size

Fixed:

- Now the write manage the power off of the data bus
- If CRC error on writing is detected another attempt is done